### PR TITLE
feat: bring Ruby SDK to parity with cashramp-sdk-node 0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## 0.2.0
+
+Parity release with `cashramp-sdk-node` 0.0.13.
+
+### Added
+
+- `initiate_hosted_payment` now accepts an optional `metadata:` hash, forwarded as the GraphQL `$metadata: JSON` variable on `initiateHostedPayment`.
+- `add_payment_method` now accepts an optional `ownership:` argument (`"first_party"` or `"third_party"`), forwarded as the GraphQL `$ownership: P2PPaymentMethodOwnership` variable.
+- `initiate_ramp_quote_deposit` now accepts an optional `onchain_transfer_info:` hash (`:address`, `:cryptocurrency`, `:network`) for onchain stablecoin delivery, forwarded as `$onchainTransferInfo: OnchainTransferInfo`.
+- `CHANGELOG.md` and gemspec metadata pointing at the public GitHub and docs URLs.
+
+### Changed
+
+- `ramp_quote` now defaults `payment_type:` to `"deposit"` when nil/omitted, matching the Node SDK.
+- `RAMP_QUOTE` query now declares `$paymentType: PaymentTypeType` (optional), matching the Node SDK.
+- `initiate_hosted_payment` makes `currency:`, `reference:`, `redirect_url:`, and `metadata:` optional (currency defaults to `"usd"`).
+- `withdraw_onchain` strips nil values from the GraphQL variables hash for consistency with the rest of the client.
+- README rewritten to mirror the Node SDK's structure (Quick Start, Hosted Payments, Direct Ramp deposits/withdrawals, onchain transfer info, API reference).
+- Bumped to `0.2.0`.
+
+### Fixed
+
+- `INITIATE_HOSTED_PAYMENT` previously sent the GraphQL variable as `redirect_url`; the API expects `redirectUrl`. The client now sends the correct camelCase key.
+- `ADD_PAYMENT_METHOD` previously declared `$paymentMethodType: ID!` and passed `p2pPaymentMethodType: $paymentMethodType` to the field; both are wrong against the current Cashramp schema. The mutation now declares `$paymentMethodType: String!` and passes `paymentMethodType: $paymentMethodType`, matching the Node SDK.
+- Removed the dead class-level `HTTParty.headers` block in `Cashramp::Client` that interpolated `@secret_key` at class-load time (always `nil`). The per-request `Authorization` header in `send_request` was already doing the right thing.
+- `lib/cashramp.rb` now requires `cashramp/version`, so `Cashramp::VERSION` is always loaded.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    cashramp_sdk_ruby (0.1.1)
+    cashramp_sdk_ruby (0.2.0)
+      httparty (~> 0.21)
 
 GEM
   remote: https://rubygems.org/
@@ -44,7 +45,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
-  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -3,462 +3,310 @@
 <a href="https://github.com/rockets-hq/cashramp-sdk-ruby/"><img src="https://github.com/rockets-hq/cashramp-sdk-ruby/actions/workflows/test.yml/badge.svg" /></a>
 <img alt="Last Commit" src="https://badgen.net/github/last-commit/rockets-hq/cashramp-sdk-ruby" />
 <a href="https://github.com/rockets-hq/cashramp-sdk-ruby/"><img src="https://img.shields.io/github/stars/rockets-hq/cashramp-sdk-ruby.svg"/></a>
-<a href="https://github.com/rockets-hq/cashramp-sdk-ruby/"><img src="https://img.shields.io/npm/l/cashramp.svg"/></a>
+<a href="https://github.com/rockets-hq/cashramp-sdk-ruby/blob/main/LICENSE.txt"><img src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
 
 The official Ruby SDK for [Cashramp's API](https://cashramp.co/commerce).
 
-## Installation
+## Table of Contents
 
-### From GitHub (Recommended)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Usage Examples](#usage-examples)
+  - [Hosted Payments](#hosted-payments)
+  - [Direct Ramp - Deposits](#direct-ramp---deposits)
+  - [Direct Ramp - Withdrawals](#direct-ramp---withdrawals)
+- [API Reference](#api-reference)
+- [Custom Queries](#custom-queries)
+- [Error Handling](#error-handling)
+
+## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "cashramp_sdk_ruby", git: "https://github.com/rockets-hq/cashramp-sdk-ruby.git"
+gem "cashramp_sdk_ruby"
 ```
 
-Then execute:
+And then run:
 
 ```bash
 bundle install
 ```
 
-### Direct Installation
-
-If you're not using Bundler, you can install directly from GitHub:
+Or install it directly with:
 
 ```bash
-gem install specific_install
-gem specific_install https://github.com/rockets-hq/cashramp-sdk-ruby.git
+gem install cashramp_sdk_ruby
 ```
 
 ## Quick Start
 
-### 1. Initialize the Client
-
 ```ruby
 require "cashramp"
 
-# Initialize with your API credentials
-client = Cashramp::Client.initialize(
-  env: :test,  # or :live for production
-  secret_key: "your_secret_key_here"
+Cashramp::Client.initialize(
+  env: :test, # :test for sandbox, :live for production
+  secret_key: "CSHRMP-SECK_your_secret_key",
 )
 ```
 
-### 2. Basic Usage Examples
+You can also configure via environment variables:
 
-#### Check Available Countries
-
-```ruby
-response = client.available_countries
-if response.success?
-  puts "Available countries: #{response.result}"
-else
-  puts "Error: #{response.error}"
-end
+```bash
+export CASHRAMP_ENV=test
+export CASHRAMP_SECRET_KEY=CSHRMP-SECK_your_secret_key
 ```
 
-#### Get Market Rates
-
 ```ruby
-response = client.market_rate(country_code: "NG")
-if response.success?
-  rates = response.result
-  puts "Deposit rate: #{rates['depositRate']}"
-  puts "Withdrawal rate: #{rates['withdrawalRate']}"
-end
+Cashramp::Client.initialize
 ```
 
-#### Create a Customer
+## Usage Examples
+
+### Hosted Payments
+
+Hosted payments redirect users to Cashramp's hosted page to complete transactions.
 
 ```ruby
-customer_data = {
-  email: "customer@example.com",
+deposit = Cashramp::Client.initiate_hosted_payment(
+  amount: 100,
+  currency: "usd", # "usd" or "local_currency"
+  country_code: "GH",
+  payment_type: "deposit",
+  reference: "order_123",
   first_name: "John",
   last_name: "Doe",
-  country_code: "US"
-}
+  email: "john@example.com",
+  redirect_url: "https://yoursite.com/callback",
+  metadata: { order_id: "order_123", user_id: "user_42" },
+)
 
-response = client.create_customer(customer_data)
-if response.success?
-  puts "Customer created: #{response.result}"
+if deposit.success?
+  # Redirect the user to the hosted page
+  puts deposit.result["hostedLink"]
 else
-  puts "Error creating customer: #{response.error}"
+  puts "Error: #{deposit.error}"
 end
 ```
 
-#### Request a Ramp Quote
+### Direct Ramp - Deposits
+
+Direct Ramp gives you full control over the payment UI. Users pay fiat and receive stablecoins.
 
 ```ruby
-quote_params = {
-  customer: "customer_id",
-  amount: 100.0,
+# Step 1: Create a customer
+customer = Cashramp::Client.create_customer(
+  first_name: "John",
+  last_name: "Doe",
+  email: "john@example.com",
+  country: "country_global_id", # from Cashramp::Client.available_countries
+)
+
+# Step 2: Get a quote
+quote = Cashramp::Client.ramp_quote(
+  customer: customer.result["id"],
+  amount: 100,
   currency: "usd",
   payment_type: "deposit",
-  payment_method_type: "mtn_momo_gh",
-  country: "GH"
-}
+  payment_method_type: "mobile_money", # from Cashramp::Client.payment_method_types
+)
 
-response = client.ramp_quote(quote_params)
-if response.success?
-  quote = response.result
+# Step 3: Initiate the deposit
+deposit = Cashramp::Client.initiate_ramp_quote_deposit(
+  ramp_quote_id: quote.result["id"],
+  reference: "order_123",
+  phone_number: "+233123456789", # for mobile money
+)
+
+if deposit.success?
+  puts deposit.result["paymentDetails"]
+  puts deposit.result["expiresAt"]
 end
+
+# Step 4: Mark as paid (after the user confirms payment)
+Cashramp::Client.mark_deposit_as_paid(
+  payment_request_id: deposit.result["id"],
+  receipt: "https://example.com/receipt.png",
+)
+```
+
+#### Receiving Stablecoins Onchain
+
+To deliver stablecoins directly to a wallet address instead of your Cashramp Merchant Dashboard balance:
+
+```ruby
+deposit = Cashramp::Client.initiate_ramp_quote_deposit(
+  ramp_quote_id: quote.result["id"],
+  reference: "order_123",
+  onchain_transfer_info: {
+    address: "0x1234567890abcdef1234567890abcdef12345678",
+    cryptocurrency: "usd_tether", # from Cashramp::Client.rampable_assets
+    network: "celo", # from Cashramp::Client.rampable_assets
+  },
+)
+```
+
+### Direct Ramp - Withdrawals
+
+Users receive fiat to their bank/mobile money in exchange for stablecoins.
+
+```ruby
+# Step 1: Create the customer (if not already done)
+customer = Cashramp::Client.create_customer(
+  first_name: "John",
+  last_name: "Doe",
+  email: "john@example.com",
+  country: "country_global_id",
+)
+
+# Step 2: Add a payment method for the customer
+payment_method = Cashramp::Client.add_payment_method(
+  customer: customer.result["id"],
+  payment_method_type: "bank_transfer",
+  fields: [
+    { identifier: "account_number", value: "1234567890" },
+    { identifier: "bank_name",      value: "Example Bank" },
+  ],
+  ownership: "first_party", # optional: "first_party" or "third_party"
+)
+
+# Step 3: Get a quote
+quote = Cashramp::Client.ramp_quote(
+  customer: customer.result["id"],
+  amount: 50,
+  currency: "usd",
+  payment_type: "withdrawal",
+  payment_method_type: "bank_transfer",
+)
+
+# Step 4: Initiate the withdrawal
+withdrawal = Cashramp::Client.initiate_ramp_quote_withdrawal(
+  ramp_quote_id: quote.result["id"],
+  payment_method_id: payment_method.result["id"],
+  reference: "withdrawal_456",
+)
+
+# Step 5: Mark as received (after the user confirms receipt)
+Cashramp::Client.mark_withdrawal_as_received(
+  payment_request_id: withdrawal.result["id"],
+)
 ```
 
 ## API Reference
 
-### Configuration
+### Queries
 
-#### Environment Variables
+| Method                                                                                  | Description                                                |
+| --------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `available_countries`                                                                   | Fetch the countries Cashramp operates in                   |
+| `market_rate(country_code:)`                                                            | Current deposit/withdrawal rates for a country             |
+| `payment_method_types(country:)`                                                        | Available payment methods for a country (global ID)        |
+| `rampable_assets`                                                                       | Supported cryptocurrencies and networks                    |
+| `ramp_limits`                                                                           | Min/max transaction limits                                 |
+| `ramp_quote(customer:, amount:, currency:, payment_method_type:, payment_type:, country:)` | Request a Direct Ramp quote (`payment_type` defaults to `"deposit"`) |
+| `refresh_ramp_quote(ramp_quote_id:, amount:)`                                           | Refresh an existing quote                                  |
+| `payment_request(reference:)`                                                           | Fetch a payment request by reference                       |
+| `account`                                                                               | Account balance and deposit address                        |
 
-You can also configure the SDK using environment variables:
+### Mutations
 
-```ruby
-# Set these in your environment or .env file
-ENV["CASHRAMP_ENV"] = "test"  # or "live"
-ENV["CASHRAMP_SECRET_KEY"] = "your_secret_key_here"
+#### Hosted Payments
 
-# Then initialize without parameters
-client = Cashramp::Client.initialize
-```
+| Method                                                                                                                                              | Description                  |
+| --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `initiate_hosted_payment(amount:, country_code:, payment_type:, first_name:, last_name:, email:, currency:, reference:, redirect_url:, metadata:)`  | Start a hosted payment       |
+| `cancel_hosted_payment(payment_request_id:)`                                                                                                        | Cancel a hosted payment      |
 
-### Query Methods
+#### Customer Management
 
-#### `available_countries`
+| Method                                                                                       | Description                              |
+| -------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `create_customer(first_name:, last_name:, email:, country:)`                                 | Create a new customer profile            |
+| `add_payment_method(customer:, payment_method_type:, fields:, ownership:)`                   | Add a payment method to a customer       |
 
-Fetch the countries where Cashramp services are available.
+#### Direct Ramp - Deposits
 
-```ruby
-response = client.available_countries
-# Returns: Array of country objects with id, name, and code
-```
+| Method                                                                                                                            | Description                       |
+| --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `initiate_ramp_quote_deposit(ramp_quote_id:, reference:, phone_number:, bank_account_number:, onchain_transfer_info:)`            | Start a deposit from a quote      |
+| `mark_deposit_as_paid(payment_request_id:, receipt:)`                                                                             | Confirm the user paid             |
+| `cancel_deposit(payment_request_id:)`                                                                                             | Cancel a deposit                  |
 
-#### `market_rate(country_code:)`
+#### Direct Ramp - Withdrawals
 
-Get current market rates for deposits and withdrawals in a specific country.
+| Method                                                                                       | Description                       |
+| -------------------------------------------------------------------------------------------- | --------------------------------- |
+| `initiate_ramp_quote_withdrawal(ramp_quote_id:, payment_method_id:, reference:)`             | Start a withdrawal from a quote   |
+| `mark_withdrawal_as_received(payment_request_id:)`                                           | Confirm the user received funds   |
 
-```ruby
-response = client.market_rate(country_code: "NG")
-# Returns: Hash with depositRate and withdrawalRate
-```
+#### Other
 
-#### `payment_method_types(country:)`
+| Method                                                                  | Description                          |
+| ----------------------------------------------------------------------- | ------------------------------------ |
+| `confirm_transaction(payment_request:, transaction_hash:)`              | Confirm crypto transfer to escrow    |
+| `withdraw_onchain(address:, amount_usd:, network:, metadata:)`          | Withdraw from balance to a wallet    |
 
-Get available payment methods for a specific country.
+#### `onchain_transfer_info` Hash
 
-```ruby
-response = client.payment_method_types(country: "country_id")
-# Returns: Array of payment method types available in the country
-```
+Used in `initiate_ramp_quote_deposit` to deliver stablecoins onchain:
 
-#### `rampable_assets`
+| Key              | Type   | Description                           |
+| ---------------- | ------ | ------------------------------------- |
+| `:address`       | String | Destination wallet address            |
+| `:cryptocurrency`| String | e.g. `"usd_tether"`, `"usd_coin"`     |
+| `:network`       | String | e.g. `"celo"`, `"polygon"`, `"base"`  |
 
-Fetch all assets available for on/off-ramping.
+## Custom Queries
 
-```ruby
-response = client.rampable_assets
-# Returns: Array of supported cryptocurrency assets
-```
-
-#### `ramp_limits`
-
-Get current limits for on/off-ramping operations.
-
-```ruby
-response = client.ramp_limits
-# Returns: Hash with minimum and maximum limits
-```
-
-#### `payment_request(reference:)`
-
-Fetch details of a specific payment request.
-
-```ruby
-response = client.payment_request(reference: "payment_ref")
-# Returns: Payment request details
-```
-
-#### `account`
-
-Get account information for the authenticated user.
+For advanced use cases, use `send_request` to execute custom GraphQL queries:
 
 ```ruby
-response = client.account
-# Returns: Account details and balance information
-```
-
-#### `ramp_quote(customer:, amount:, currency:, payment_type:, payment_method_type:, country: nil)`
-
-Request a quote for a Direct Ramp transaction.
-
-```ruby
-response = client.ramp_quote(
-  customer: "customer_id",
-  amount: 100.0,
-  currency: "usd",
-  payment_type: "deposit",
-  payment_method_type: "bank_transfer_ng",
-  country: "NG"
-)
-# Returns: Quote object with pricing and transaction details
-```
-
-#### `refresh_ramp_quote(ramp_quote_id:, amount: nil)`
-
-Refresh an existing Ramp Quote.
-
-```ruby
-response = client.refresh_ramp_quote(ramp_quote_id: "quote_id", amount: 150.0)
-# Returns: Updated quote object
-```
-
-### Mutation Methods
-
-#### `confirm_transaction(payment_request:, transaction_hash:)`
-
-Confirm a cryptocurrency transaction sent to Cashramp's escrow address.
-
-```ruby
-response = client.confirm_transaction(
-  payment_request: "payment_request_id",
-  transaction_hash: "0x..."
-)
-# Returns: Transaction confirmation response
-```
-
-#### `initiate_hosted_payment(amount:, currency:, country_code:, payment_type:, reference:, redirect_url:, first_name:, last_name:, email:)`
-
-Initiate a hosted payment request
-
-```ruby
-response = client.initiate_hosted_payment(
-  amount: 100.0,
-  currency: "usd",
-  country_code: "NG",
-  payment_type: "deposit",
-  reference: "unique_ref_123",
-  redirect_url: "https://yourapp.com/callback",
-  first_name: "Gabriel",
-  last_name: "Okocha",
-  email: "gabby@example.com"
-)
-# Returns: Payment request object with id, hostedLink, and status
-```
-
-#### `cancel_hosted_payment(payment_request_id:)`
-
-Cancel a hosted payment request.
-
-```ruby
-response = client.cancel_hosted_payment(
-  payment_request_id: "payment_request_id"
-)
-# Returns: Cancellation confirmation response
-```
-
-#### `create_customer(first_name:, last_name:, email:, country:)`
-
-Create a new customer profile.
-
-```ruby
-customer = client.create_customer({
-  first_name: "Chinedu",
-  last_name: "Okorie",
-  email: "chinedu@example.com",
-  country: "country_id"
-})
-# Returns: Created customer object with ID
-```
-
-#### `add_payment_method(customer:, payment_method_type:, fields:)`
-
-Add a payment method for an existing customer.
-
-```ruby
-payment_method = client.add_payment_method({
-  customer: "customer_id",
-  payment_method_type: "payment_method_type_id",
-  fields: [
-    { identifier: "", value: "" }
-  ]
-})
-# Returns: Created payment method object
-```
-
-#### `withdraw_onchain(address:, amount_usd:, network:, metadata:)`
-
-Withdraw your current balance as stablecoins to an on-chain wallet address.
-
-```ruby
-response = client.withdraw_onchain(
-  address: "0x...",
-  amount_usd: 100,
-  network: "OP"
-  metadata: { reference: "xyz" }
-)
-# Returns: Withdrawal transaction details
-```
-
-#### `initiate_ramp_quote_deposit(ramp_quote_id:, reference: nil, phone_number: nil, bank_account_number: nil)`
-
-Initiate a deposit transaction using a ramp quote.
-
-```ruby
-response = client.initiate_ramp_quote_deposit(
-  ramp_quote_id: "quote_id",
-  reference: "unique_reference",
-  phone_number: "+233273448978"
-)
-# Returns: Deposit initiation response
-```
-
-#### `mark_deposit_as_paid(payment_request_id:, receipt: nil)`
-
-Mark a deposit as paid by the customer.
-
-```ruby
-response = client.mark_deposit_as_paid(
-  payment_request_id: "payment_request_id",
-  receipt: "https://example.com/receipt.jpg"
-)
-# Returns: Payment confirmation response
-```
-
-#### `cancel_deposit(payment_request_id:)`
-
-Cancel an initiated deposit.
-
-```ruby
-response = client.cancel_deposit(
-  payment_request_id: "payment_request_id"
-)
-# Returns: Cancellation confirmation response
-```
-
-#### `initiate_ramp_quote_withdrawal(ramp_quote_id:, payment_method_id:, reference: nil)`
-
-Initiate a withdrawal transaction using a ramp quote.
-
-```ruby
-response = client.initiate_ramp_quote_withdrawal(
-  ramp_quote_id: "quote_id",
-  payment_method_id: "payment_method_id",
-  reference: "unique_reference"
-)
-# Returns: Withdrawal initiation response
-```
-
-#### `mark_withdrawal_as_received(payment_request_id)`
-
-Mark a withdrawal as received by the customer.
-
-```ruby
-response = client.mark_withdrawal_as_received(
-  payment_request_id: "payment_request_id"
-)
-# Returns: Withdrawal confirmation response
-```
-
-## Advanced Usage
-
-### Custom GraphQL Queries
-
-For advanced use cases, you can send custom GraphQL queries directly:
-
-```ruby
-query = <<-GRAPHQL
-  query GetAvailableCountries {
+query = <<~GRAPHQL
+  query {
     availableCountries {
-      code
+      id
       name
+      code
+      currency {
+        isoCode
+        name
+      }
     }
   }
 GRAPHQL
 
-response = client.send_request(
+response = Cashramp::Client.send_request(
   name: "availableCountries",
   query: query,
-  variables: {}
 )
 
+puts response.result if response.success?
+```
+
+## Error Handling
+
+All methods return a `Cashramp::Client::Response` struct with `success?`, `result`, and `error`:
+
+```ruby
+response = Cashramp::Client.market_rate(country_code: "GH")
+
 if response.success?
-  puts "Available countries: #{response.result}"
+  puts "Deposit rate:    #{response.result["depositRate"]}"
+  puts "Withdrawal rate: #{response.result["withdrawalRate"]}"
 else
-  puts "Error: #{response.error}"
+  warn "Error: #{response.error}"
 end
 ```
 
-### Error Handling
+## Documentation
 
-All SDK methods return a response object with consistent error handling:
-
-```ruby
-response = client.available_countries
-
-if response.success?
-  # Success - access the result
-  countries = response.result
-  puts "Found #{countries.length} countries"
-else
-  # Error - check the error details
-  puts "Error: #{response.error}"
-  # Handle the error appropriately
-end
-```
-
-### Response Object Structure
-
-```ruby
-# Success response
-{
-  success?: true,
-  result: { /* API response data */ },
-  error: nil
-}
-
-# Error response
-{
-  success?: false,
-  result: nil,
-  error: "Error message or details"
-}
-```
-
-## Getting API Credentials
-
-1. Visit [Accrue Commerce](https://cashramp.co/commerce)
-2. Sign up or log in to your account
-3. Navigate to Developer Settings
-4. Generate your API keys
-5. Use the secret key in your application configuration
-
-## Testing
-
-The SDK supports both test and live environments:
-
-```ruby
-# Test environment (default for development)
-client = Cashramp::Client.initialize(env: :test, secret_key: "test_key")
-
-# Live environment (for production)
-client = Cashramp::Client.initialize(env: :live, secret_key: "live_key")
-```
+For detailed API documentation and webhook integration, visit the [Cashramp API docs](https://docs.cashramp.co).
 
 ## Support
 
-- 📚 [API Documentation](https://docs.cashramp.co)
-- 💬 [Support Center](mailto:cashramp@useaccrue.com)
-- 🐛 [Report Issues](https://github.com/rockets-hq/cashramp-sdk-ruby/issues)
-
-### Reporting Issues
-
-Found a bug? Please report it on [GitHub Issues](https://github.com/rockets-hq/cashramp-sdk-ruby/issues) with:
-
-- Ruby version
-- Gem version
-- Steps to reproduce
-- Expected vs actual behavior
+- [API Documentation](https://docs.cashramp.co)
+- [Support](mailto:cashramp@useaccrue.com)
+- [Report Issues](https://github.com/rockets-hq/cashramp-sdk-ruby/issues)
 
 ## License
 

--- a/cashramp.gemspec
+++ b/cashramp.gemspec
@@ -5,11 +5,13 @@ require_relative "lib/cashramp/version"
 Gem::Specification.new do |spec|
   spec.name = "cashramp_sdk_ruby"
   spec.version = Cashramp::VERSION
-  spec.authors = ["olawolu"]
-  spec.email = ["gbemigaolawolu@gmail.com"]
+  spec.authors = ["Cashramp"]
+  spec.email = ["support@useaccrue.com"]
 
-  spec.summary = "The official Ruby SDK for Cashramp's API"
-  spec.description = "The official Ruby SDK for Cashramp's API"
+  spec.summary = "Official Ruby SDK for the Cashramp API."
+  spec.description = "Ruby client for the Cashramp API (https://cashramp.co/commerce). " \
+                     "Supports Hosted Payments, Direct Ramp deposits and withdrawals, " \
+                     "onchain stablecoin delivery, and Cashramp's full GraphQL surface."
   spec.homepage = "https://github.com/rockets-hq/cashramp-sdk-ruby"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.1.0"
@@ -18,6 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/rockets-hq/cashramp-sdk-ruby"
+  spec.metadata["changelog_uri"] = "https://github.com/rockets-hq/cashramp-sdk-ruby/blob/main/CHANGELOG.md"
+  spec.metadata["documentation_uri"] = "https://docs.cashramp.co"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -32,9 +36,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
+  spec.add_dependency "httparty", "~> 0.21"
 end

--- a/lib/cashramp.rb
+++ b/lib/cashramp.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'httparty'
+require "cashramp/version"
 require "cashramp/client"
 require "cashramp/queries"
 require "cashramp/mutations"

--- a/lib/cashramp/client.rb
+++ b/lib/cashramp/client.rb
@@ -5,11 +5,6 @@ module Cashramp
 
       attr_reader :env, :secret_key
 
-      headers({
-        "Content-Type" => "application/json",
-        "Authorization" => "Bearer #{@secret_key}",
-      })
-
       API_URLS = {
         live: "https://api.useaccrue.com/cashramp/api/graphql",
         test: "https://staging.api.useaccrue.com/cashramp/api/graphql",
@@ -30,8 +25,7 @@ module Cashramp
       # ------- QUERIES -------
 
       # Fetch the countries that Cashramp is available in
-      # @return [Response] Response object with success status and result containing array of countries
-      # @return [Array<Hash>] result.countries Array of country objects with id, name, and code
+      # @return [Response] result is an Array of Hashes with id, name, and code
       def available_countries
         send_request(
           name: "availableCountries",
@@ -40,9 +34,8 @@ module Cashramp
       end
 
       # Fetch the Cashramp market rate for a country
-      # @param [String] country_code ISO country code to get market rates for
-      # @return [Response] Response object with success status and result containing market rates
-      # @return [Hash] result.market_rate Object with depositRate and withdrawalRate
+      # @param [String] country_code Two-letter ISO 3166-1 country code
+      # @return [Response] result has depositRate and withdrawalRate
       def market_rate(country_code:)
         send_request(
           name: "marketRate",
@@ -51,10 +44,8 @@ module Cashramp
         )
       end
 
-      # Fetch the payment methods available in a country
-      # @param [String] country Country ID to get payment method types for
-      # @return [Response] Response object with success status and result containing payment method types
-      # @return [Array<Hash>] result.payment_method_types Array of payment method objects with id, identifier, label, and fields
+      # Fetch the payment method types available in a country
+      # @param [String] country The country's global ID
       def payment_method_types(country:)
         send_request(
           name: "p2pPaymentMethodTypes",
@@ -64,8 +55,6 @@ module Cashramp
       end
 
       # Fetch the assets you can on/off-ramp with the Onchain Ramp
-      # @return [Response] Response object with success status and result containing rampable assets
-      # @return [Array<Hash>] result.rampable_assets Array of asset objects with name, symbol, networks, and contractAddress
       def rampable_assets
         send_request(
           name: "rampableAssets",
@@ -74,8 +63,6 @@ module Cashramp
       end
 
       # Fetch the Onchain Ramp limits
-      # @return [Response] Response object with success status and result containing ramp limits
-      # @return [Hash] result.ramp_limits Object with minimumDepositUsd, maximumDepositUsd, minimumWithdrawalUsd, maximumWithdrawalUsd, and dailyLimitUsd
       def ramp_limits
         send_request(
           name: "rampLimits",
@@ -84,9 +71,7 @@ module Cashramp
       end
 
       # Fetch the details of a payment request
-      # @param [String] reference Payment request reference to fetch details for
-      # @return [Response] Response object with success status and result containing payment request details
-      # @return [Hash] result.payment_request Object with id, paymentType, hostedLink, amount, currency, reference, and status
+      # @param [String] reference Payment request reference
       def payment_request(reference:)
         send_request(
           name: "merchantPaymentRequest",
@@ -95,9 +80,7 @@ module Cashramp
         )
       end
 
-      # Fetch the details of an account
-      # @return [Response] Response object with success status and result containing account details
-      # @return [Hash] result.account Object with id, accountBalance, and depositAddress
+      # Fetch the account information for the authenticated user
       def account
         send_request(
           name: "account",
@@ -105,16 +88,14 @@ module Cashramp
         )
       end
 
-      # Get a ramp quote for currency conversion
-      # @param [String] customer Global ID of the paying customer
-      # @param [Numeric] amount Amount to convert
-      # @param [String] currency 'local_currency' or 'usd'
-      # @param [String] payment_type 'deposit' or 'withdrawal'
-      # @param [String] payment_method_type Payment rail identifier (e.g., 'bank_transfer_ng')
-      # @param [String] country Optional ISO 3166-2 country code
-      # @return [Response] Response object with success status and result containing quote details
-      # @return [Hash] result.ramp_quote Object with id, exchangeRate, and paymentType
-      def ramp_quote(customer:, amount:, currency:, payment_type:, payment_method_type:, country: nil)
+      # Request a new Ramp Quote for a Direct Ramp payment
+      # @param [String] customer Customer's global ID
+      # @param [Numeric] amount Amount to ramp
+      # @param [String] currency 'usd' or 'local_currency'
+      # @param [String] payment_type 'deposit' or 'withdrawal' (default: 'deposit')
+      # @param [String] payment_method_type Payment method identifier
+      # @param [String] country Optional ISO 3166-1 country code
+      def ramp_quote(customer:, amount:, currency:, payment_method_type:, payment_type: nil, country: nil)
         send_request(
           name: "rampQuote",
           query: Queries::RAMP_QUOTE,
@@ -122,18 +103,16 @@ module Cashramp
             customer: customer,
             amount: amount,
             currency: currency,
-            paymentType: payment_type,
+            paymentType: payment_type || "deposit",
             paymentMethodType: payment_method_type,
             country: country,
           }.compact,
         )
       end
 
-      # Refresh an existing ramp quote
-      # @param [String] ramp_quote_id ID of the quote to refresh
+      # Refresh an existing Ramp Quote
+      # @param [String] ramp_quote_id Quote's global ID
       # @param [Numeric] amount Optional new amount (keeps original if omitted)
-      # @return [Response] Response object with success status and result containing refreshed quote
-      # @return [Hash] result.refreshed_quote Object with id, exchangeRate, and paymentType
       def refresh_ramp_quote(ramp_quote_id:, amount: nil)
         send_request(
           name: "refreshRampQuote",
@@ -147,10 +126,7 @@ module Cashramp
 
       # ------- MUTATIONS -------
 
-      # Confirm a crypto transfer sent into the Cashramp's Secure Escrow address
-      # @param [String] payment_request Payment request ID to confirm
-      # @param [String] transaction_hash Transaction hash of the crypto transfer
-      # @return [Response] Response object with success status and confirmation result
+      # Confirm a crypto transfer sent into Cashramp's Secure Escrow address
       def confirm_transaction(payment_request:, transaction_hash:)
         send_request(
           name: "confirmTransaction",
@@ -161,17 +137,17 @@ module Cashramp
 
       # Initiate a hosted payment request
       # @param [Numeric] amount Payment amount
-      # @param [String] currency Payment currency (default: "usd")
-      # @param [String] country_code Country code for the payment
-      # @param [String] payment_type Type of payment
-      # @param [String] reference Unique reference for the payment
-      # @param [String] redirect_url URL to redirect after payment
+      # @param [String] country_code Two-letter ISO 3166-1 country code
+      # @param [String] payment_type 'deposit' or 'withdrawal'
       # @param [String] first_name Customer's first name
       # @param [String] last_name Customer's last name
       # @param [String] email Customer's email address
-      # @return [Response] Response object with success status and result containing payment details
-      # @return [Hash] result.payment_request Object with id, hostedLink, and status
-      def initiate_hosted_payment(amount:, currency:, country_code:, payment_type:, reference:, redirect_url:, first_name:, last_name:, email:)
+      # @param [String] currency Optional payment currency (default: 'usd')
+      # @param [String] reference Optional payment request reference
+      # @param [String] redirect_url Optional URL to redirect to after payment
+      # @param [Hash] metadata Optional metadata echoed in webhooks
+      def initiate_hosted_payment(amount:, country_code:, payment_type:, first_name:, last_name:, email:,
+                                   currency: nil, reference: nil, redirect_url: nil, metadata: nil)
         send_request(
           name: "initiateHostedPayment",
           query: Mutations::INITIATE_HOSTED_PAYMENT,
@@ -181,61 +157,77 @@ module Cashramp
             countryCode: country_code,
             paymentType: payment_type,
             reference: reference,
-            redirect_url: redirect_url,
+            redirectUrl: redirect_url,
+            metadata: metadata,
             firstName: first_name,
             lastName: last_name,
             email: email,
-          },
+          }.compact,
         )
       end
 
       # Cancel a hosted payment request
-      # @param [String] payment_request_id ID of the payment request to cancel
-      # @return [Response] Response object with success status and cancellation result
       def cancel_hosted_payment(payment_request_id:)
-        send_request(name: "cancelHostedPayment", query: Mutations::CANCEL_HOSTED_PAYMENT, variables: { paymentRequest: payment_request_id })
+        send_request(
+          name: "cancelHostedPayment",
+          query: Mutations::CANCEL_HOSTED_PAYMENT,
+          variables: { paymentRequest: payment_request_id },
+        )
       end
 
       # Create a new customer profile
-      #
-      # @param [String] first_name Customer's first name
-      # @param [String] last_name Customer's last name
-      # @param [String] email Customer's email address
-      # @param [String] country Country ID for the customer
-      # @return [Response] Response object with success status and result containing customer details
-      # @return [Hash] result.customer Object with id, email, firstName, lastName, and country
       def create_customer(first_name:, last_name:, email:, country:)
-        send_request(name: "createCustomer", query: Mutations::CREATE_CUSTOMER, variables: { firstName: first_name, lastName: last_name, email: email, country: country })
+        send_request(
+          name: "createCustomer",
+          query: Mutations::CREATE_CUSTOMER,
+          variables: { firstName: first_name, lastName: last_name, email: email, country: country },
+        )
       end
 
       # Add a payment method for an existing customer
-      #
-      # @param [String] customer Customer ID
-      # @param [String] payment_method_type Payment method type
-      # @param [Hash] fields Payment method fields
-      # @return [Response] Response object with success status and result containing payment method details
-      # @return [Hash] result.payment_method Object with id, value, and fields
-      def add_payment_method(customer:, payment_method_type:, fields:)
-        send_request(name: "addPaymentMethod", query: Mutations::ADD_PAYMENT_METHOD, variables: { customer: customer, paymentMethodType: payment_method_type, fields: fields })
+      # @param [String] customer Customer's global ID
+      # @param [String] payment_method_type Payment method type identifier
+      # @param [Array<Hash>] fields Payment method fields ([{ identifier:, value: }, ...])
+      # @param [String] ownership Optional 'first_party' or 'third_party'
+      def add_payment_method(customer:, payment_method_type:, fields:, ownership: nil)
+        send_request(
+          name: "addPaymentMethod",
+          query: Mutations::ADD_PAYMENT_METHOD,
+          variables: {
+            customer: customer,
+            paymentMethodType: payment_method_type,
+            fields: fields,
+            ownership: ownership,
+          }.compact,
+        )
       end
 
       # Withdraw from your balance to an onchain wallet address
-      # @param [String] address Onchain wallet address to withdraw to
+      # @param [String] address Wallet address to withdraw to
       # @param [Numeric] amount_usd Amount to withdraw in USD
-      # @return [Response] Response object with success status and result containing withdrawal details
-      # @return [Hash] result.withdrawal Object with id and status
+      # @param [String] network Optional network to withdraw on
+      # @param [Hash] metadata Optional metadata for the withdrawal
       def withdraw_onchain(address:, amount_usd:, network: nil, metadata: nil)
-        send_request(name: "withdrawOnchain", query: Mutations::WITHDRAW_ONCHAIN, variables: { address: address, amountUsd: amount_usd, network: network, metadata: metadata })
+        send_request(
+          name: "withdrawOnchain",
+          query: Mutations::WITHDRAW_ONCHAIN,
+          variables: {
+            address: address,
+            amountUsd: amount_usd,
+            network: network,
+            metadata: metadata,
+          }.compact,
+        )
       end
 
-      # Initiate a ramp quote deposit (convert local currency to stablecoins)
-      # @param [String] ramp_quote_id Quote ID from rampQuote query
-      # @param [String] reference Optional unique reference for reconciliation
+      # Initiate a Ramp Quote deposit
+      # @param [String] ramp_quote_id Quote's global ID
+      # @param [String] reference Optional reference for the payment request
       # @param [String] phone_number Customer's phone number if paying via MoMo
       # @param [String] bank_account_number Customer's bank account number if paying via bank
-      # @return [Response] Response object with success status and result containing deposit details
-      # @return [Hash] result.deposit Object with id, status, agent, paymentDetails, exchangeRate, amountLocal, amountUsd, and expiresAt
-      def initiate_ramp_quote_deposit(ramp_quote_id:, reference: nil, phone_number: nil, bank_account_number: nil)
+      # @param [Hash] onchain_transfer_info Optional Hash with :address, :cryptocurrency, :network for onchain stablecoin delivery
+      def initiate_ramp_quote_deposit(ramp_quote_id:, reference: nil, phone_number: nil,
+                                       bank_account_number: nil, onchain_transfer_info: nil)
         send_request(
           name: "initiateRampQuoteDeposit",
           query: Mutations::INITIATE_RAMP_QUOTE_DEPOSIT,
@@ -244,14 +236,12 @@ module Cashramp
             reference: reference,
             phoneNumber: phone_number,
             bankAccountNumber: bank_account_number,
+            onchainTransferInfo: onchain_transfer_info,
           }.compact,
         )
       end
 
-      # Mark a deposit as paid by the customer
-      # @param [String] payment_request_id Deposit request ID
-      # @param [String] receipt Optional payment proof URL
-      # @return [Response] Response object with success status and payment confirmation result
+      # Mark a deposit payment request as paid
       def mark_deposit_as_paid(payment_request_id:, receipt: nil)
         send_request(
           name: "markDepositAsPaid",
@@ -263,9 +253,7 @@ module Cashramp
         )
       end
 
-      # Cancel an initiated deposit
-      # @param [String] payment_request_id Deposit request ID to cancel
-      # @return [Response] Response object with success status and cancellation result
+      # Cancel a deposit payment request
       def cancel_deposit(payment_request_id:)
         send_request(
           name: "cancelDeposit",
@@ -274,12 +262,7 @@ module Cashramp
         )
       end
 
-      # Initiate a ramp quote withdrawal (convert stablecoins to local currency)
-      # @param [String] ramp_quote_id Quote ID from rampQuote query
-      # @param [String] payment_method_id Customer's payment method ID
-      # @param [String] reference Optional unique reference for reconciliation
-      # @return [Response] Response object with success status and result containing withdrawal details
-      # @return [Hash] result.withdrawal Object with id, status, agent, paymentDetails, exchangeRate, amountUsd, and amountLocal
+      # Initiate a Ramp Quote withdrawal
       def initiate_ramp_quote_withdrawal(ramp_quote_id:, payment_method_id:, reference: nil)
         send_request(
           name: "initiateRampQuoteWithdrawal",
@@ -292,9 +275,7 @@ module Cashramp
         )
       end
 
-      # Mark a withdrawal as received by the customer
-      # @param [String] payment_request_id Withdrawal request ID
-      # @return [Response] Response object with success status and withdrawal confirmation result
+      # Mark a withdrawal payment request as received
       def mark_withdrawal_as_received(payment_request_id:)
         send_request(
           name: "markWithdrawalAsReceived",

--- a/lib/cashramp/mutations.rb
+++ b/lib/cashramp/mutations.rb
@@ -8,7 +8,7 @@ module Cashramp
       GRAPHQL
 
       INITIATE_HOSTED_PAYMENT = <<~GRAPHQL
-        mutation ($amount: Decimal!, $currency: P2PPaymentCurrency, $countryCode: String!, $email: String!, $paymentType: P2PPaymentTypeType!, $reference: String!, $firstName: String!, $lastName: String!, $redirectUrl: String) {
+        mutation ($amount: Decimal!, $currency: P2PPaymentCurrency, $countryCode: String!, $email: String!, $paymentType: P2PPaymentTypeType!, $reference: String!, $firstName: String!, $lastName: String!, $redirectUrl: String, $metadata: JSON) {
           initiateHostedPayment(
             amount: $amount,
             currency: $currency,
@@ -18,12 +18,13 @@ module Cashramp
             reference: $reference,
             firstName: $firstName,
             lastName: $lastName,
-            redirectUrl: $redirectUrl
+            redirectUrl: $redirectUrl,
+            metadata: $metadata
           ) {
-              id
-              hostedLink
-              status
-            }
+            id
+            hostedLink
+            status
+          }
         }
       GRAPHQL
 
@@ -50,8 +51,8 @@ module Cashramp
       GRAPHQL
 
       ADD_PAYMENT_METHOD = <<~GRAPHQL
-        mutation ($customer: ID!, $paymentMethodType: ID!, $fields: [P2PPaymentMethodFieldInput!]!) {
-          addPaymentMethod(customer: $customer, p2pPaymentMethodType: $paymentMethodType, fields: $fields) {
+        mutation ($customer: ID!, $paymentMethodType: String!, $fields: [P2PPaymentMethodFieldInput!]!, $ownership: P2PPaymentMethodOwnership) {
+          addPaymentMethod(customer: $customer, paymentMethodType: $paymentMethodType, fields: $fields, ownership: $ownership) {
             id
             value
             fields {
@@ -72,12 +73,13 @@ module Cashramp
       GRAPHQL
 
       INITIATE_RAMP_QUOTE_DEPOSIT = <<~GRAPHQL
-        mutation ($rampQuote: ID!, $reference: String, $phoneNumber: String, $bankAccountNumber: String) {
+        mutation ($rampQuote: ID!, $reference: String, $phoneNumber: String, $bankAccountNumber: String, $onchainTransferInfo: OnchainTransferInfo) {
           initiateRampQuoteDeposit(
             rampQuote: $rampQuote,
             reference: $reference,
             phoneNumber: $phoneNumber,
-            bankAccountNumber: $bankAccountNumber
+            bankAccountNumber: $bankAccountNumber,
+            onchainTransferInfo: $onchainTransferInfo
           ) {
             id
             status

--- a/lib/cashramp/queries.rb
+++ b/lib/cashramp/queries.rb
@@ -85,7 +85,7 @@ module Cashramp
         GRAPHQL
 
       RAMP_QUOTE = <<~GRAPHQL
-        query ($customer: ID!, $amount: Decimal!, $currency: P2PPaymentCurrency!, $paymentType: PaymentTypeType!, $paymentMethodType: String!, $country: String) {
+        query ($customer: ID!, $amount: Decimal!, $currency: P2PPaymentCurrency!, $paymentType: PaymentTypeType, $paymentMethodType: String!, $country: String) {
           rampQuote(
             customer: $customer,
             amount: $amount,

--- a/lib/cashramp/version.rb
+++ b/lib/cashramp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Cashramp
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/spec/cashramp/client_spec.rb
+++ b/spec/cashramp/client_spec.rb
@@ -33,10 +33,7 @@ RSpec.describe Cashramp::Client do
       before do
         stub_request(:post, "https://staging.api.useaccrue.com/cashramp/api/graphql")
           .with(
-            body: {
-              query: query,
-              variables: {}
-            }.to_json,
+            body: { query: query, variables: {} }.to_json,
             headers: {
               'Content-Type' => 'application/json',
               'Authorization' => 'Bearer test_key'
@@ -60,10 +57,7 @@ RSpec.describe Cashramp::Client do
       context 'when the request returns GraphQL errors' do
         let(:status_code) { 200 }
         let(:response_body) do
-          {
-            data: nil,
-            errors: [{ message: 'GraphQL Error' }]
-          }.to_json
+          { data: nil, errors: [{ message: 'GraphQL Error' }] }.to_json
         end
 
         it 'returns a failure response with error message' do
@@ -77,7 +71,7 @@ RSpec.describe Cashramp::Client do
         let(:status_code) { 400 }
         let(:response_body) { 'Bad Request' }
 
-        it 'returns a failure response with status text' do
+        it 'returns a failure response' do
           result = Cashramp::Client.send_request(name: name, query: query)
           expect(result.success?).to be false
         end
@@ -86,11 +80,12 @@ RSpec.describe Cashramp::Client do
       context 'when HTTParty raises an error' do
         let(:status_code) { 400 }
         let(:response_body) { 'Bad Request' }
+
         before do
           allow(HTTParty).to receive(:post).and_raise(HTTParty::Error.new('Network error'))
         end
 
-        it 'returns a failure response with error message' do
+        it 'returns a failure response with the error message' do
           result = Cashramp::Client.send_request(name: name, query: query)
           expect(result.success?).to be false
           expect(result.error).to eq('Network error')
@@ -98,362 +93,562 @@ RSpec.describe Cashramp::Client do
       end
     end
 
-    describe '.available_countries' do
-      it 'sends request with correct parameters' do
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'availableCountries',
-          query: Cashramp::Client::Queries::AVAILABLE_COUNTRIES
-        )
+    describe 'queries' do
+      describe '.available_countries' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'availableCountries',
+            query: Cashramp::Client::Queries::AVAILABLE_COUNTRIES,
+          )
 
-        c = Cashramp::Client.available_countries
+          Cashramp::Client.available_countries
+        end
+      end
+
+      describe '.market_rate' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'marketRate',
+            query: Cashramp::Client::Queries::MARKET_RATE,
+            variables: { countryCode: 'NG' },
+          )
+
+          Cashramp::Client.market_rate(country_code: 'NG')
+        end
+      end
+
+      describe '.payment_method_types' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'p2pPaymentMethodTypes',
+            query: Cashramp::Client::Queries::PAYMENT_METHOD_TYPES,
+            variables: { country: 'country_id' },
+          )
+
+          Cashramp::Client.payment_method_types(country: 'country_id')
+        end
+      end
+
+      describe '.rampable_assets' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'rampableAssets',
+            query: Cashramp::Client::Queries::RAMPABLE_ASSETS,
+          )
+
+          Cashramp::Client.rampable_assets
+        end
+      end
+
+      describe '.ramp_limits' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'rampLimits',
+            query: Cashramp::Client::Queries::RAMP_LIMITS,
+          )
+
+          Cashramp::Client.ramp_limits
+        end
+      end
+
+      describe '.payment_request' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'merchantPaymentRequest',
+            query: Cashramp::Client::Queries::PAYMENT_REQUEST,
+            variables: { reference: 'ref123' },
+          )
+
+          Cashramp::Client.payment_request(reference: 'ref123')
+        end
+      end
+
+      describe '.account' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'account',
+            query: Cashramp::Client::Queries::ACCOUNT,
+          )
+
+          Cashramp::Client.account
+        end
       end
     end
 
-    describe '.market_rate' do
-      it 'sends request with correct parameters' do
-        country_code = 'US'
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'marketRate',
-          query: Cashramp::Client::Queries::MARKET_RATE,
-          variables: { countryCode: country_code }
-        )
+    describe 'mutations' do
+      describe '.confirm_transaction' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'confirmTransaction',
+            query: Cashramp::Client::Mutations::CONFIRM_TRANSACTION,
+            variables: { paymentRequest: 'pr123', transactionHash: 'tx456' },
+          )
 
-        Cashramp::Client.market_rate(country_code: country_code)
+          Cashramp::Client.confirm_transaction(payment_request: 'pr123', transaction_hash: 'tx456')
+        end
+      end
+
+      describe '.initiate_hosted_payment' do
+        let(:base_params) do
+          {
+            amount: 100,
+            country_code: 'GH',
+            payment_type: 'deposit',
+            first_name: 'John',
+            last_name: 'Doe',
+            email: 'john@example.com',
+          }
+        end
+
+        it 'forwards required fields and defaults currency to "usd"' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'initiateHostedPayment',
+            query: Cashramp::Client::Mutations::INITIATE_HOSTED_PAYMENT,
+            variables: {
+              amount: 100,
+              currency: 'usd',
+              countryCode: 'GH',
+              paymentType: 'deposit',
+              firstName: 'John',
+              lastName: 'Doe',
+              email: 'john@example.com',
+            },
+          )
+
+          Cashramp::Client.initiate_hosted_payment(**base_params)
+        end
+
+        it 'forwards optional reference, redirect_url, metadata using camelCase keys' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'initiateHostedPayment',
+            query: Cashramp::Client::Mutations::INITIATE_HOSTED_PAYMENT,
+            variables: {
+              amount: 100,
+              currency: 'local_currency',
+              countryCode: 'GH',
+              paymentType: 'deposit',
+              reference: 'ref_123',
+              redirectUrl: 'https://example.com/cb',
+              metadata: { order_id: 'order_123' },
+              firstName: 'John',
+              lastName: 'Doe',
+              email: 'john@example.com',
+            },
+          )
+
+          Cashramp::Client.initiate_hosted_payment(
+            **base_params,
+            currency: 'local_currency',
+            reference: 'ref_123',
+            redirect_url: 'https://example.com/cb',
+            metadata: { order_id: 'order_123' },
+          )
+        end
+
+        it 'sends metadata: $metadata in the GraphQL mutation string' do
+          expect(Cashramp::Client::Mutations::INITIATE_HOSTED_PAYMENT).to include('$metadata: JSON')
+          expect(Cashramp::Client::Mutations::INITIATE_HOSTED_PAYMENT).to include('metadata: $metadata')
+          expect(Cashramp::Client::Mutations::INITIATE_HOSTED_PAYMENT).to include('redirectUrl: $redirectUrl')
+        end
+      end
+
+      describe '.cancel_hosted_payment' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'cancelHostedPayment',
+            query: Cashramp::Client::Mutations::CANCEL_HOSTED_PAYMENT,
+            variables: { paymentRequest: 'pr123' },
+          )
+
+          Cashramp::Client.cancel_hosted_payment(payment_request_id: 'pr123')
+        end
+      end
+
+      describe '.create_customer' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'createCustomer',
+            query: Cashramp::Client::Mutations::CREATE_CUSTOMER,
+            variables: {
+              firstName: 'John',
+              lastName: 'Doe',
+              email: 'john@example.com',
+              country: 'country_id',
+            },
+          )
+
+          Cashramp::Client.create_customer(
+            first_name: 'John',
+            last_name: 'Doe',
+            email: 'john@example.com',
+            country: 'country_id',
+          )
+        end
+      end
+
+      describe '.add_payment_method' do
+        let(:fields) { [{ identifier: 'account_number', value: '1234567890' }] }
+
+        it 'sends without ownership when omitted' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'addPaymentMethod',
+            query: Cashramp::Client::Mutations::ADD_PAYMENT_METHOD,
+            variables: {
+              customer: 'cust123',
+              paymentMethodType: 'bank_transfer',
+              fields: fields,
+            },
+          )
+
+          Cashramp::Client.add_payment_method(
+            customer: 'cust123',
+            payment_method_type: 'bank_transfer',
+            fields: fields,
+          )
+        end
+
+        it 'forwards ownership when provided' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'addPaymentMethod',
+            query: Cashramp::Client::Mutations::ADD_PAYMENT_METHOD,
+            variables: {
+              customer: 'cust123',
+              paymentMethodType: 'bank_transfer',
+              fields: fields,
+              ownership: 'third_party',
+            },
+          )
+
+          Cashramp::Client.add_payment_method(
+            customer: 'cust123',
+            payment_method_type: 'bank_transfer',
+            fields: fields,
+            ownership: 'third_party',
+          )
+        end
+
+        it 'declares the GraphQL paymentMethodType variable as String! and passes it correctly' do
+          expect(Cashramp::Client::Mutations::ADD_PAYMENT_METHOD).to include('$paymentMethodType: String!')
+          expect(Cashramp::Client::Mutations::ADD_PAYMENT_METHOD).to include('paymentMethodType: $paymentMethodType')
+          expect(Cashramp::Client::Mutations::ADD_PAYMENT_METHOD).not_to include('p2pPaymentMethodType:')
+          expect(Cashramp::Client::Mutations::ADD_PAYMENT_METHOD).to include('$ownership: P2PPaymentMethodOwnership')
+        end
+      end
+
+      describe '.withdraw_onchain' do
+        it 'sends only the supplied variables, compacting nils' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'withdrawOnchain',
+            query: Cashramp::Client::Mutations::WITHDRAW_ONCHAIN,
+            variables: { address: '0x123', amountUsd: 100 },
+          )
+
+          Cashramp::Client.withdraw_onchain(address: '0x123', amount_usd: 100)
+        end
+
+        it 'forwards optional network and metadata' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'withdrawOnchain',
+            query: Cashramp::Client::Mutations::WITHDRAW_ONCHAIN,
+            variables: {
+              address: '0x123',
+              amountUsd: 100,
+              network: 'celo',
+              metadata: { reference: 'xyz' },
+            },
+          )
+
+          Cashramp::Client.withdraw_onchain(
+            address: '0x123',
+            amount_usd: 100,
+            network: 'celo',
+            metadata: { reference: 'xyz' },
+          )
+        end
       end
     end
 
-    describe '.payment_method_types' do
-      it 'sends request with correct parameters' do
-        country_code = 'US'
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'p2pPaymentMethodTypes',
-          query: Cashramp::Client::Queries::PAYMENT_METHOD_TYPES,
-          variables: { country: country_code }
-        )
+    describe 'Direct Ramp' do
+      describe '.ramp_quote' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'rampQuote',
+            query: Cashramp::Client::Queries::RAMP_QUOTE,
+            variables: {
+              customer: 'customer_id',
+              amount: 100.0,
+              currency: 'usd',
+              paymentType: 'withdrawal',
+              paymentMethodType: 'bank_transfer_ng',
+              country: 'NG',
+            },
+          )
 
-        Cashramp::Client.payment_method_types(country: country_code)
+          Cashramp::Client.ramp_quote(
+            customer: 'customer_id',
+            amount: 100.0,
+            currency: 'usd',
+            payment_type: 'withdrawal',
+            payment_method_type: 'bank_transfer_ng',
+            country: 'NG',
+          )
+        end
+
+        it 'defaults payment_type to "deposit" when omitted' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'rampQuote',
+            query: Cashramp::Client::Queries::RAMP_QUOTE,
+            variables: {
+              customer: 'customer_id',
+              amount: 100.0,
+              currency: 'usd',
+              paymentType: 'deposit',
+              paymentMethodType: 'mtn_momo_gh',
+            },
+          )
+
+          Cashramp::Client.ramp_quote(
+            customer: 'customer_id',
+            amount: 100.0,
+            currency: 'usd',
+            payment_method_type: 'mtn_momo_gh',
+          )
+        end
+
+        it 'declares $paymentType as optional in the GraphQL query' do
+          expect(Cashramp::Client::Queries::RAMP_QUOTE).to include('$paymentType: PaymentTypeType,')
+          expect(Cashramp::Client::Queries::RAMP_QUOTE).not_to include('$paymentType: PaymentTypeType!')
+        end
       end
-    end
 
-    describe '.rampable_assets' do
-      it 'sends request with correct parameters' do
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'rampableAssets',
-          query: Cashramp::Client::Queries::RAMPABLE_ASSETS
-        )
+      describe '.refresh_ramp_quote' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'refreshRampQuote',
+            query: Cashramp::Client::Queries::REFRESH_RAMP_QUOTE,
+            variables: { rampQuote: 'quote_id', amount: 150.0 },
+          )
 
-        Cashramp::Client.rampable_assets
+          Cashramp::Client.refresh_ramp_quote(ramp_quote_id: 'quote_id', amount: 150.0)
+        end
       end
-    end
 
-    describe '.ramp_limits' do
-      it 'sends request with correct parameters' do
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'rampLimits',
-          query: Cashramp::Client::Queries::RAMP_LIMITS
-        )
+      describe '.initiate_ramp_quote_deposit' do
+        it 'forwards rampQuote and other variables, compacting nils' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'initiateRampQuoteDeposit',
+            query: Cashramp::Client::Mutations::INITIATE_RAMP_QUOTE_DEPOSIT,
+            variables: {
+              rampQuote: 'quote_id',
+              reference: 'ref_123',
+              phoneNumber: '+234123456789',
+            },
+          )
 
-        Cashramp::Client.ramp_limits
+          Cashramp::Client.initiate_ramp_quote_deposit(
+            ramp_quote_id: 'quote_id',
+            reference: 'ref_123',
+            phone_number: '+234123456789',
+          )
+        end
+
+        it 'forwards onchain_transfer_info as $onchainTransferInfo (camelCase)' do
+          info = {
+            address: '0x1234567890abcdef1234567890abcdef12345678',
+            cryptocurrency: 'usd_tether',
+            network: 'celo',
+          }
+
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'initiateRampQuoteDeposit',
+            query: Cashramp::Client::Mutations::INITIATE_RAMP_QUOTE_DEPOSIT,
+            variables: {
+              rampQuote: 'quote_id',
+              reference: 'ref_123',
+              onchainTransferInfo: info,
+            },
+          )
+
+          Cashramp::Client.initiate_ramp_quote_deposit(
+            ramp_quote_id: 'quote_id',
+            reference: 'ref_123',
+            onchain_transfer_info: info,
+          )
+        end
+
+        it 'declares $onchainTransferInfo: OnchainTransferInfo in the mutation' do
+          expect(Cashramp::Client::Mutations::INITIATE_RAMP_QUOTE_DEPOSIT)
+            .to include('$onchainTransferInfo: OnchainTransferInfo')
+          expect(Cashramp::Client::Mutations::INITIATE_RAMP_QUOTE_DEPOSIT)
+            .to include('onchainTransferInfo: $onchainTransferInfo')
+        end
       end
-    end
 
-    describe '.payment_request' do
-      it 'sends request with correct parameters' do
-        reference = 'ref123'
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'merchantPaymentRequest',
-          query: Cashramp::Client::Queries::PAYMENT_REQUEST,
-          variables: { reference: reference }
-        )
+      describe '.mark_deposit_as_paid' do
+        it 'forwards receipt when provided' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'markDepositAsPaid',
+            query: Cashramp::Client::Mutations::MARK_DEPOSIT_AS_PAID,
+            variables: { paymentRequest: 'payment_123', receipt: 'https://example.com/receipt.png' },
+          )
 
-        Cashramp::Client.payment_request(reference: reference)
+          Cashramp::Client.mark_deposit_as_paid(
+            payment_request_id: 'payment_123',
+            receipt: 'https://example.com/receipt.png',
+          )
+        end
+
+        it 'compacts nil receipt' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'markDepositAsPaid',
+            query: Cashramp::Client::Mutations::MARK_DEPOSIT_AS_PAID,
+            variables: { paymentRequest: 'payment_123' },
+          )
+
+          Cashramp::Client.mark_deposit_as_paid(payment_request_id: 'payment_123')
+        end
       end
-    end
 
-    describe '.account' do
-      it 'sends request with correct parameters' do
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'account',
-          query: Cashramp::Client::Queries::ACCOUNT,
-        )
+      describe '.cancel_deposit' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'cancelDeposit',
+            query: Cashramp::Client::Mutations::CANCEL_DEPOSIT,
+            variables: { paymentRequest: 'payment_123' },
+          )
 
-        Cashramp::Client.account
+          Cashramp::Client.cancel_deposit(payment_request_id: 'payment_123')
+        end
+      end
+
+      describe '.initiate_ramp_quote_withdrawal' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'initiateRampQuoteWithdrawal',
+            query: Cashramp::Client::Mutations::INITIATE_RAMP_QUOTE_WITHDRAWAL,
+            variables: {
+              rampQuote: 'quote_id',
+              paymentMethod: 'payment_method_123',
+              reference: 'ref_456',
+            },
+          )
+
+          Cashramp::Client.initiate_ramp_quote_withdrawal(
+            ramp_quote_id: 'quote_id',
+            payment_method_id: 'payment_method_123',
+            reference: 'ref_456',
+          )
+        end
+      end
+
+      describe '.mark_withdrawal_as_received' do
+        it 'sends request with correct parameters' do
+          expect(Cashramp::Client).to receive(:send_request).with(
+            name: 'markWithdrawalAsReceived',
+            query: Cashramp::Client::Mutations::MARK_WITHDRAWAL_AS_RECEIVED,
+            variables: { paymentRequest: 'payment_456' },
+          )
+
+          Cashramp::Client.mark_withdrawal_as_received(payment_request_id: 'payment_456')
+        end
       end
     end
   end
 
-  describe 'Mutations' do
-    describe '.confirm_transaction' do
-      it 'sends request with correct parameters' do
-        payment_request = 'pr123'
-        transaction_hash = 'tx456'
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'confirmTransaction',
-          query: Cashramp::Client::Mutations::CONFIRM_TRANSACTION,
-          variables: {
-            paymentRequest: payment_request,
-            transactionHash: transaction_hash
-          }
-        )
-
-        Cashramp::Client.confirm_transaction(
-          payment_request: payment_request,
-          transaction_hash: transaction_hash
-        )
-      end
+  describe 'wire-level GraphQL payloads' do
+    before(:all) do
+      Cashramp::Client.initialize(env: :test, secret_key: 'test_key')
     end
 
-    describe '.initiate_hosted_payment' do
-      it 'sends request with correct parameters' do
-        payment_params = {
+    let(:endpoint) { 'https://staging.api.useaccrue.com/cashramp/api/graphql' }
+
+    it 'sends initiate_hosted_payment with redirectUrl (camelCase) and metadata' do
+      expected_body = {
+        query: Cashramp::Client::Mutations::INITIATE_HOSTED_PAYMENT,
+        variables: {
           amount: 100,
           currency: 'usd',
-          country_code: 'US',
-          payment_type: 'BANK_TRANSFER',
-          reference: 'ref123',
-          redirect_url: 'https://example.com',
-          first_name: 'John',
-          last_name: 'Doe',
-          email: 'john@example.com'
-        }
-
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'initiateHostedPayment',
-          query: Cashramp::Client::Mutations::INITIATE_HOSTED_PAYMENT,
-          variables: {
-            amount: payment_params[:amount],
-            currency: payment_params[:currency],
-            countryCode: payment_params[:country_code],
-            paymentType: payment_params[:payment_type],
-            reference: payment_params[:reference],
-            redirect_url: payment_params[:redirect_url],
-            firstName: payment_params[:first_name],
-            lastName: payment_params[:last_name],
-            email: payment_params[:email]
-          }
-        )
-
-        Cashramp::Client.initiate_hosted_payment(**payment_params)
-      end
-    end
-
-    describe '.cancel_hosted_payment' do
-      it 'sends request with correct parameters' do
-        payment_request_id = 'pr123'
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'cancelHostedPayment',
-          query: Cashramp::Client::Mutations::CANCEL_HOSTED_PAYMENT,
-          variables: { paymentRequest: payment_request_id }
-        )
-
-        Cashramp::Client.cancel_hosted_payment(payment_request_id: payment_request_id)
-      end
-    end
-
-    describe '.create_customer' do
-      it 'sends request with correct parameters' do
-        customer_details = {
-          first_name: 'John',
-          last_name: 'Doe',
+          countryCode: 'GH',
+          paymentType: 'deposit',
+          reference: 'order_123',
+          redirectUrl: 'https://example.com/cb',
+          metadata: { order_id: 'order_123' },
+          firstName: 'John',
+          lastName: 'Doe',
           email: 'john@example.com',
-          country: 'US'
-        }
+        },
+      }.to_json
 
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'createCustomer',
-          query: Cashramp::Client::Mutations::CREATE_CUSTOMER,
-          variables: { firstName: 'John', lastName: 'Doe', email: 'john@example.com', country: 'US' }
-        )
+      stub_request(:post, endpoint)
+        .with(body: expected_body)
+        .to_return(status: 200, body: { data: { initiateHostedPayment: { id: 'p_1' } } }.to_json)
 
-        Cashramp::Client.create_customer(**customer_details)
-      end
+      response = Cashramp::Client.initiate_hosted_payment(
+        amount: 100,
+        country_code: 'GH',
+        payment_type: 'deposit',
+        reference: 'order_123',
+        redirect_url: 'https://example.com/cb',
+        metadata: { order_id: 'order_123' },
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'john@example.com',
+      )
+
+      expect(response.success?).to be true
+      expect(response.result).to eq({ 'id' => 'p_1' })
     end
 
-    describe '.add_payment_method' do
-      it 'sends request with correct parameters' do
-        payment_method_options = {
-          customer: 'cust123',
-          payment_method_type: 'bank_transfer',
-          fields: [{ name: 'account_number', value: '123456' }]
-        }
+    it 'sends add_payment_method with paymentMethodType (not p2pPaymentMethodType)' do
+      fields = [{ identifier: 'account_number', value: '1234567890' }]
+      expected_body = {
+        query: Cashramp::Client::Mutations::ADD_PAYMENT_METHOD,
+        variables: {
+          customer: 'cust_1',
+          paymentMethodType: 'bank_transfer',
+          fields: fields,
+          ownership: 'first_party',
+        },
+      }.to_json
 
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'addPaymentMethod',
-          query: Cashramp::Client::Mutations::ADD_PAYMENT_METHOD,
-          variables: { customer: 'cust123', paymentMethodType: 'bank_transfer', fields: [{ name: 'account_number', value: '123456' }] }
-        )
+      stub_request(:post, endpoint)
+        .with(body: expected_body)
+        .to_return(status: 200, body: { data: { addPaymentMethod: { id: 'pm_1' } } }.to_json)
 
-        Cashramp::Client.add_payment_method(**payment_method_options)
-      end
+      response = Cashramp::Client.add_payment_method(
+        customer: 'cust_1',
+        payment_method_type: 'bank_transfer',
+        fields: fields,
+        ownership: 'first_party',
+      )
+
+      expect(response.success?).to be true
     end
 
-    describe '.withdraw_onchain' do
-      it 'sends request with correct parameters' do
-        withdraw_options = {
-          address: '0x123...',
-          amount_usd: 100
-        }
+    it 'sends initiate_ramp_quote_deposit with onchainTransferInfo' do
+      info = {
+        address: '0xabc',
+        cryptocurrency: 'usd_tether',
+        network: 'celo',
+      }
+      expected_body = {
+        query: Cashramp::Client::Mutations::INITIATE_RAMP_QUOTE_DEPOSIT,
+        variables: {
+          rampQuote: 'quote_1',
+          onchainTransferInfo: info,
+        },
+      }.to_json
 
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'withdrawOnchain',
-          query: Cashramp::Client::Mutations::WITHDRAW_ONCHAIN,
-          variables: { address: '0x123...', amountUsd: 100, network: nil, metadata: nil }
-        )
+      stub_request(:post, endpoint)
+        .with(body: expected_body)
+        .to_return(status: 200, body: { data: { initiateRampQuoteDeposit: { id: 'd_1' } } }.to_json)
 
-        Cashramp::Client.withdraw_onchain(**withdraw_options)
-      end
-    end
-  end
+      response = Cashramp::Client.initiate_ramp_quote_deposit(
+        ramp_quote_id: 'quote_1',
+        onchain_transfer_info: info,
+      )
 
-  describe 'Direct Ramp' do
-    describe '.ramp_quote' do
-      it 'sends request with correct parameters' do
-        customer = 'customer_id'
-        amount = 100.0
-        currency = 'usd'
-        payment_type = 'deposit'
-        payment_method_type = 'bank_transfer_ng'
-        country = 'NG'
-
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'rampQuote',
-          query: Cashramp::Client::Queries::RAMP_QUOTE,
-          variables: {
-            customer: customer,
-            amount: amount,
-            currency: currency,
-            paymentType: payment_type,
-            paymentMethodType: payment_method_type,
-            country: country
-          }
-        )
-
-        Cashramp::Client.ramp_quote(
-          customer: customer,
-          amount: amount,
-          currency: currency,
-          payment_type: payment_type,
-          payment_method_type: payment_method_type,
-          country: country
-        )
-      end
-    end
-
-    describe '.refresh_ramp_quote' do
-      it 'sends request with correct parameters' do
-        ramp_quote_id = 'quote_id'
-        amount = 150.0
-
-         expect(Cashramp::Client).to receive(:send_request).with(
-           name: 'refreshRampQuote',
-           query: Cashramp::Client::Queries::REFRESH_RAMP_QUOTE,
-           variables: { rampQuote: ramp_quote_id, amount: amount }
-         )
-
-        Cashramp::Client.refresh_ramp_quote(
-          ramp_quote_id: ramp_quote_id,
-          amount: amount
-        )
-      end
-    end
-
-    describe '.initiate_ramp_quote_deposit' do
-      it 'sends request with correct parameters' do
-        ramp_quote_id = 'quote_id'
-        reference = 'ref_123'
-        phone_number = '+234123456789'
-        bank_account_number = '1234567890'
-
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'initiateRampQuoteDeposit',
-          query: Cashramp::Client::Mutations::INITIATE_RAMP_QUOTE_DEPOSIT,
-          variables: {
-            rampQuote: ramp_quote_id,
-            reference: reference,
-            phoneNumber: phone_number,
-            bankAccountNumber: bank_account_number
-          }
-        )
-
-        Cashramp::Client.initiate_ramp_quote_deposit(
-          ramp_quote_id: ramp_quote_id,
-          reference: reference,
-          phone_number: phone_number,
-          bank_account_number: bank_account_number
-        )
-      end
-    end
-
-    describe '.mark_deposit_as_paid' do
-      it 'sends request with correct parameters' do
-        payment_request_id = 'payment_123'
-        receipt = 'https://example.com/receipt.png'
-
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'markDepositAsPaid',
-          query: Cashramp::Client::Mutations::MARK_DEPOSIT_AS_PAID,
-          variables: { paymentRequest: payment_request_id, receipt: receipt }
-        )
-
-        Cashramp::Client.mark_deposit_as_paid(
-          payment_request_id: payment_request_id,
-          receipt: receipt
-        )
-      end
-    end
-
-    describe '.cancel_deposit' do
-      it 'sends request with correct parameters' do
-        payment_request_id = 'payment_123'
-
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'cancelDeposit',
-          query: Cashramp::Client::Mutations::CANCEL_DEPOSIT,
-          variables: { paymentRequest: payment_request_id }
-        )
-
-        Cashramp::Client.cancel_deposit(payment_request_id: payment_request_id)
-      end
-    end
-
-    describe '.initiate_ramp_quote_withdrawal' do
-      it 'sends request with correct parameters' do
-        ramp_quote_id = 'quote_id'
-        payment_method_id = 'payment_method_123'
-        reference = 'ref_456'
-
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'initiateRampQuoteWithdrawal',
-          query: Cashramp::Client::Mutations::INITIATE_RAMP_QUOTE_WITHDRAWAL,
-          variables: {
-            rampQuote: ramp_quote_id,
-            paymentMethod: payment_method_id,
-            reference: reference
-          }
-        )
-
-        Cashramp::Client.initiate_ramp_quote_withdrawal(
-          ramp_quote_id: ramp_quote_id,
-          payment_method_id: payment_method_id,
-          reference: reference
-        )
-      end
-    end
-
-    describe '.mark_withdrawal_as_received' do
-      it 'sends request with correct parameters' do
-        payment_request_id = 'payment_456'
-
-        expect(Cashramp::Client).to receive(:send_request).with(
-          name: 'markWithdrawalAsReceived',
-          query: Cashramp::Client::Mutations::MARK_WITHDRAWAL_AS_RECEIVED,
-          variables: { paymentRequest: payment_request_id }
-        )
-
-        Cashramp::Client.mark_withdrawal_as_received(
-          payment_request_id: payment_request_id
-        )
-      end
+      expect(response.success?).to be true
     end
   end
 end


### PR DESCRIPTION
## Summary

Brings `cashramp_sdk_ruby` to feature- and bug-parity with `cashramp-sdk-node` 0.0.13. After this change a developer should be able to translate a Node SDK call to Ruby (camelCase → snake_case) one-for-one and get the same result against the Cashramp API.

### Parity items addressed

- **`initiate_hosted_payment` / `INITIATE_HOSTED_PAYMENT`**
  - Adds optional `metadata:` keyword and `$metadata: JSON` GraphQL variable.
  - Makes `currency:`, `reference:`, `redirect_url:`, `metadata:` optional; `currency` defaults to `"usd"`.
  - **Bug fix:** the variables hash now sends `redirectUrl:` (camelCase) instead of `redirect_url:`. The previous key was silently ignored by the API.
- **`add_payment_method` / `ADD_PAYMENT_METHOD`**
  - Adds optional `ownership:` (`"first_party"` | `"third_party"`).
  - **Bug fix:** mutation now declares `$paymentMethodType: String!` (was `ID!`) and passes `paymentMethodType: $paymentMethodType` (was the broken `p2pPaymentMethodType:` field arg).
  - Adds `$ownership: P2PPaymentMethodOwnership` and forwards `ownership` in variables.
- **`initiate_ramp_quote_deposit` / `INITIATE_RAMP_QUOTE_DEPOSIT`**
  - Adds optional `onchain_transfer_info:` (`{ address:, cryptocurrency:, network: }`) and `$onchainTransferInfo: OnchainTransferInfo` GraphQL variable for onchain stablecoin delivery.
- **`ramp_quote` / `RAMP_QUOTE`**
  - `payment_type:` is now optional and defaults to `"deposit"`, mirroring Node.
  - Query declares `$paymentType: PaymentTypeType` (optional).
- **`withdraw_onchain`** — compacts nil values out of variables for consistency with the rest of the client (`network`/`metadata` already accepted as keyword args).
- **Client setup hygiene** — removed the dead class-level `HTTParty.headers` block that interpolated `@secret_key` at class-load time (always `nil`). The per-request `Authorization` header in `send_request` already does the right thing. `lib/cashramp.rb` now requires `cashramp/version`.
- **Gem metadata** — replaced `TODO` placeholders in `cashramp.gemspec` with real summary, description, homepage, allowed_push_host, source_code_uri, changelog_uri, authors, and email. Bumped `Cashramp::VERSION` to `0.2.0` and added `CHANGELOG.md`.
- **README rewrite** — now mirrors the Node SDK README (Quick Start, Hosted Payments with metadata + redirectUrl, Direct Ramp deposits, deposits with `onchain_transfer_info`, Direct Ramp withdrawals with `add_payment_method` ownership, API Reference table, Custom Queries via `send_request`, Error Handling). Filled in the empty `initiate_hosted_payment` example and fixed the missing comma in the `withdraw_onchain` snippet.
- **Tests** — `spec/cashramp/client_spec.rb` rewritten with coverage for the new surface, including wire-level webmock assertions confirming the corrected GraphQL variable names (`redirectUrl`, `paymentMethodType`, `onchainTransferInfo`).

## Test plan

- [x] `bundle exec rspec` — 42 examples, 0 failures.
- [ ] Smoke-test against the staging environment using `playground.rb` (createCustomer + addPaymentMethod with/without ownership, getRampQuote deposit + withdrawal, initiateRampQuoteDeposit with `onchain_transfer_info`, initiateRampQuoteWithdrawal, initiateHostedPayment with metadata) — to be captured before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)